### PR TITLE
Allow for non-ASCII decoding in legacy demangling

### DIFF
--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -63,11 +63,6 @@ pub fn demangle(s: &str) -> Result<(Demangle, &str), ()> {
         return Err(());
     };
 
-    // only work with ascii text
-    if inner.bytes().any(|c| c & 0x80 != 0) {
-        return Err(());
-    }
-
     let mut elements = 0;
     let mut chars = inner.chars();
     let mut c = chars.next().ok_or(())?;
@@ -87,8 +82,9 @@ pub fn demangle(s: &str) -> Result<(Demangle, &str), ()> {
 
         // `c` already contains the first character of this identifier, skip it and
         // all the other characters of this identifier, to reach the next element.
-        for _ in 0..len {
+        while len > 0 {
             c = chars.next().ok_or(())?;
+            len = len.checked_sub(c.len_utf8()).ok_or(())?;
         }
 
         elements += 1;


### PR DESCRIPTION
There are some rare situations (I'm currently in one) where one needs non-ASCII demangling. This change implements non-ASCII support for legacy demangling.