### PR TITLE
Always omit zero disambiguators on crate-roots

### DIFF
--- a/src/v0.rs
+++ b/src/v0.rs
@@ -803,7 +803,7 @@ impl<'a, 'b, 's> Printer<'a, 'b, 's> {
 
                 self.print(name)?;
                 if let Some(out) = &mut self.out {
-                    if !out.alternate() {
+                    if !out.alternate() && dis != 0 {
                         out.write_str("[")?;
                         fmt::LowerHex::fmt(&dis, out)?;
                         out.write_str("]")?;
@@ -1271,7 +1271,7 @@ mod tests {
             t_const!($mangled, $value);
             t!(
                 concat!("_RIC0K", $mangled, "E"),
-                concat!("[0]::<", $value, $value_ty_suffix, ">")
+                concat!("::<", $value, $value_ty_suffix, ">")
             );
         }};
     }
@@ -1279,6 +1279,12 @@ mod tests {
     #[test]
     fn demangle_crate_with_leading_digit() {
         t_nohash!("_RNvC6_123foo3bar", "123foo::bar");
+    }
+
+    #[test]
+    fn demangle_crate_with_zero_disambiguator() {
+        t!("_RC4f128", "f128");
+        t_nohash!("_RC4f128", "f128");
     }
 
     #[test]


### PR DESCRIPTION
This PR makes rustc-demangle always omit zero-valued disambiguators of `crate-root` paths. There is [an accompanying PR](https://github.com/rust-lang/rust/pull/124514) to the symbol mangling documentation, which more explicitly recommends this behavior and gives some rationale for it. However, the behavior is already in line with existing documentation. E.g. the original RFC states that [zero-disambiguators can always be omitted](https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#appendix-a---suggested-demangling), and [the current documentation](https://github.com/rust-lang/rust/blob/90846015cc99aa90290c1f4ee95c571fff6901ef/src/doc/rustc/src/symbol-mangling/v0.md#path-crate-root) also omits the disambiguators for `crate-root`. 

Being able to rely on `C3foo` to be rendered as `foo` (i.e. without explicit disambiguator value) rather than as `foo[0]` allows the compiler to encode things like new basic types in a backward compatible way. This idea has been originally proposed by @eddyb in https://github.com/rust-lang/rust/pull/122106. It is a generally useful mechanism for supporting a certain class of new elements in the v0 mangling scheme in a backward compatible way (whether as a temporary workaround until downstream tooling has picked up grammar changes or as a permanent encoding).

cc @tgross35