### PR TITLE
Add a CI workflow to publish new releases after a tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to crates.io
+        run: |
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,27 @@
-name: Release
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
 
 on:
-  workflow_dispatch:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Publish to crates.io
-        run: |
-          cargo publish
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust (rustup)
+        run: rustup update nightly --no-self-update && rustup default nightly
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Context: https://github.com/rust-lang/infra-team/issues/117

This repo has `write` access by `t-compiler` and `t-compiler-contributors`, and currently this workflow creates a release after a push of a tag or manually through `workflow_dispatch`. If we don't want to give right to publish to `t-compiler-contributors`, then we can remove the `workflow_dispatch` trigger, and create a branch protection to e.g. `v-*` tags that would only allow `t-compiler` to push.

Requires a new secret `CARGO_REGISTRY_TOKEN` to be added to the secrets of this repository, which has scoped access to publish `rustc-demangle`.