### PR TITLE
Add license files into the capi crate tarball

### DIFF
--- a/crates/capi/LICENSE-APACHE
+++ b/crates/capi/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/capi/LICENSE-MIT
+++ b/crates/capi/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Symlinks are added up to the license files in the repository root.

This ensures projects that include the source code for this project will also get a copy of the licenses.

Fixes #72.