### PR TITLE
Release 0.1.1

### DIFF
--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-demangle-capi"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Torste Aikio <zokier@gmail.com>"]
 description = """
 C API for the `rustc-demangle` crate


### PR DESCRIPTION
This includes the license files (see #73).

Already pushed to crates.io (https://crates.io/crates/rustc-demangle-capi).