### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ members = ["crates/capi", "fuzz"]
 
 [dependencies]
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
-compiler_builtins = { version = '0.1.2', optional = true }
 
 [features]
-rustc-dep-of-std = ['core', 'compiler_builtins']
+rustc-dep-of-std = ['core']
 std = []
 
 [profile.release]


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993